### PR TITLE
Fix ToWordyTime (now proven by unit tests)

### DIFF
--- a/Garsonix.TimeGame/Garsonix.TimeGame.Tests/Extensions/NodaTimeExtensionTests.cs
+++ b/Garsonix.TimeGame/Garsonix.TimeGame.Tests/Extensions/NodaTimeExtensionTests.cs
@@ -1,0 +1,29 @@
+﻿using Garsonix.TimeGame.Extensions;
+using NodaTime;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Garsonix.TimeGame.Tests.Extensions
+{
+    public class NodaTimeExtensionTests
+    {
+        [Theory]
+        [MemberData(nameof(GetData))]
+        public void ToWordyStringTests(LocalTime time, string expectedWordyString)
+        {
+            // Arrange / Act
+            var wordy = time.ToWordyString();
+
+            // Assert
+            Assert.Equal(expectedWordyString, wordy);
+        }
+
+        public static IEnumerable<object[]> GetData()
+        {
+            yield return new object[] { new LocalTime(0, 0), "12 o'clock" };
+            yield return new object[] { new LocalTime(1, 0), "1 o'clock" };
+            yield return new object[] { new LocalTime(1, 5), "5 past 1" };
+            yield return new object[] { new LocalTime(1, 55), "5 to 2" };
+        }
+    }
+}

--- a/Garsonix.TimeGame/Garsonix.TimeGame.Tests/Extensions/NodaTimeExtensionTests.cs
+++ b/Garsonix.TimeGame/Garsonix.TimeGame.Tests/Extensions/NodaTimeExtensionTests.cs
@@ -21,9 +21,15 @@ namespace Garsonix.TimeGame.Tests.Extensions
         public static IEnumerable<object[]> GetData()
         {
             yield return new object[] { new LocalTime(0, 0), "12 o'clock" };
+            yield return new object[] { new LocalTime(12, 0), "12 o'clock" };
             yield return new object[] { new LocalTime(1, 0), "1 o'clock" };
             yield return new object[] { new LocalTime(1, 5), "5 past 1" };
             yield return new object[] { new LocalTime(1, 55), "5 to 2" };
+            yield return new object[] { new LocalTime(13, 30), "half past 1" };
+            yield return new object[] { new LocalTime(12, 15), "quarter past 12" };
+            yield return new object[] { new LocalTime(15, 45), "quarter to 4" };
+            yield return new object[] { new LocalTime(14, 40), "20 to 3" };
+            yield return new object[] { new LocalTime(3, 20), "20 past 3" };
         }
     }
 }

--- a/Garsonix.TimeGame/Garsonix.TimeGame/Extensions/NodaTimeExtensions.cs
+++ b/Garsonix.TimeGame/Garsonix.TimeGame/Extensions/NodaTimeExtensions.cs
@@ -11,9 +11,10 @@ namespace Garsonix.TimeGame.Extensions
                 case 0:
                     return $"{Hour(time)} o'clock";
                 case 15:
+                case 45:
                     return $"quarter {PlaceWord(time.Minute)} {Hour(time)}";
                 case 30:
-                    return $"Half past {Hour(time)}";
+                    return $"half past {Hour(time)}";
                 default:
                     return $"{Minute(time)} {PlaceWord(time.Minute)} {Hour(time)}";
             }

--- a/Garsonix.TimeGame/Garsonix.TimeGame/Extensions/NodaTimeExtensions.cs
+++ b/Garsonix.TimeGame/Garsonix.TimeGame/Extensions/NodaTimeExtensions.cs
@@ -6,8 +6,6 @@ namespace Garsonix.TimeGame.Extensions
     {
         public static string ToWordyString(this LocalTime time)
         {
-            
-
             switch(time.Minute)
             {
                 case 0:
@@ -17,7 +15,7 @@ namespace Garsonix.TimeGame.Extensions
                 case 30:
                     return $"Half past {Hour(time)}";
                 default:
-                    return $"{time.Minute} {PlaceWord(time.Minute)} {Hour(time)}";
+                    return $"{Minute(time)} {PlaceWord(time.Minute)} {Hour(time)}";
             }
 
         }
@@ -28,8 +26,8 @@ namespace Garsonix.TimeGame.Extensions
         private static string PlaceWord(int minute)
         {
             return minute > 30
-                ? "past"
-                : "to";
+                ? "to"
+                : "past";
         }
 
         private static int Hour(LocalTime time)
@@ -42,6 +40,13 @@ namespace Garsonix.TimeGame.Extensions
                 ? hour
                 : 12;
             return hour;
+        }
+
+        private static int Minute(LocalTime time)
+        {
+            return time.Minute > 30
+                ? 60 - time.Minute
+                : time.Minute;
         }
 
     }


### PR DESCRIPTION
Added test cases for all types of word time descriptions. Fixed ToWordyString so it works for all of them.